### PR TITLE
Remove redundant generation of pip deps into Dockerfile

### DIFF
--- a/dxlbootstrap/generate/templates/app/static/Dockerfile.tmpl
+++ b/dxlbootstrap/generate/templates/app/static/Dockerfile.tmpl
@@ -3,9 +3,6 @@ FROM python:2.7-slim
 
 VOLUME ["/opt/${name}-config"]
 
-# Install required packages
-${pipInstall}
-
 # Copy application files
 COPY . /tmp/build
 WORKDIR /tmp/build
@@ -13,11 +10,8 @@ WORKDIR /tmp/build
 # Clean application
 RUN python ./clean.py
 
-# Build application
-RUN python ./setup.py bdist_wheel
-
-# Install application
-RUN pip install dist/*.whl
+# Install application package and its dependencies
+RUN pip install .
 
 # Cleanup build
 RUN rm -rf /tmp/build

--- a/dxlbootstrap/generate/templates/app/template.py
+++ b/dxlbootstrap/generate/templates/app/template.py
@@ -215,24 +215,6 @@ class AppTemplate(Template):
         """
         return AppTemplateConfig(config)
 
-    @staticmethod
-    def create_pip_install(config):
-        """
-        Used to create the text content for "RUN pip install..." lines within the Dockerfile
-
-        :param config: The application configuration
-        :return: The text content for "RUN pip install..." lines within the Dockerfile
-        """
-        ret = ""
-        first = True
-        for req in config.application_section.install_requires:
-            if first:
-                ret += "RUN pip install"
-            ret += " \"{0}\"".format(req)
-            first = False
-
-        return ret
-
     def _build_root_directory(self, context, components_dict):
         """
         Builds the "root" directory components of the output
@@ -283,8 +265,7 @@ class AppTemplate(Template):
         root.add_child(file_comp)
 
         file_comp = FileTemplateComponent("Dockerfile", "Dockerfile.tmpl",
-                                          {"name": app_section.name,
-                                           "pipInstall": self.create_pip_install(config)})
+                                          {"name": app_section.name})
         root.add_child(file_comp)
 
     @staticmethod


### PR DESCRIPTION
This commit removes the lines from the generation of an application
Dockerfile which previously installed service dependencies and built a
separate wheel file. The generated Dockerfile instead just pip installs
the current project, which installs the application package and its
dependencies defined in the setup.py file.