### PR TITLE
Coerce values read from config to unicode strings

### DIFF
--- a/dxlbootstrap/generate/core/template.py
+++ b/dxlbootstrap/generate/core/template.py
@@ -125,7 +125,8 @@ class TemplateConfigSection(object):
         """
         ret = default_value
         if self._config.has_option(self._section_name, property_name):
-            ret = self._config.get(self._section_name, property_name)
+            value = self._config.get(self._section_name, property_name)
+            ret = value.decode() if isinstance(value, bytes) else value
         elif required:
             raise NoOptionError(property_name, self._section_name)
         return ret


### PR DESCRIPTION
Previously, when values were read from the config, they would be coerced
to unicode strings if the configparser package was installed on Python 2
but would be bytes (str) if not. Leaving the value as bytes would result
in exceptions being thrown by consumers expecting the values to be
unicode strings. In this commit, the values are coerced to unicode
strings whether or not the configparser package is installed, avoiding
the exceptions which were previously thrown.