### PR TITLE
Add missing colon to Python programming language classifier

### DIFF
--- a/dxlbootstrap/generate/core/template.py
+++ b/dxlbootstrap/generate/core/template.py
@@ -469,7 +469,7 @@ class Template(ABCMeta('ABC', (object,), {'__slots__': ()})): # compatible metac
         :param version: Supported language version in the configuration.
         :return: The string for use with the 'classifiers' field in setup.py.
         """
-        program_language_base = '"Programming Language : Python'
+        program_language_base = '"Programming Language :: Python'
         line_delimiter = "\n        "
         classifiers = line_delimiter + program_language_base + '",'
 


### PR DESCRIPTION
Previously, the generated 'Programming Language' classifiers errantly
omitted a colon before the word "Python". This commit adds the extra
colon.