### PR TITLE
Fixes for pylint issues

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -133,7 +133,8 @@ disable=print-statement,
         too-few-public-methods,
         too-many-instance-attributes,
         too-many-locals,
-        similarities
+        similarities,
+        useless-object-inheritance
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/dxlbootstrap/client.py
+++ b/dxlbootstrap/client.py
@@ -52,5 +52,4 @@ class Client(object):
         # Return a dictionary corresponding to the response payload
         if res.message_type != Message.MESSAGE_TYPE_ERROR:
             return res
-        else:
-            raise Exception("Error: " + res.error_message + " (" + str(res.error_code) + ")")
+        raise Exception("Error: " + res.error_message + " (" + str(res.error_code) + ")")

--- a/dxlbootstrap/generate/core/template.py
+++ b/dxlbootstrap/generate/core/template.py
@@ -513,7 +513,7 @@ class Template(ABCMeta('ABC', (object,), {'__slots__': ()})): # compatible metac
         """
         if version == PythonPackageConfigSection.UNIVERSAL_LANGUAGE_VERSION:
             image_version = "3"
-        elif version == "3" or version == "2":
+        elif version in ("2", "3"):
             image_version = version
         else:
             raise Exception("Unexpected version passed into " +


### PR DESCRIPTION
This commit includes fixes for various issues flagged by a run with the
most recently released pylint versions - 1.9.3 (for Python 2.7) and
2.1.1 (for Python 3.x).

The recently added `useless-object-inheritance` checker is disabled in
order to allow new-style classes deriving from the base `object` type
to be used for Python 2 compatibility without flagging violations
for pylint versions running under Python 3.x.